### PR TITLE
Default baseScore property for new custom tags.

### DIFF
--- a/buttons/helpers/buttons_sbd_menu_config.js
+++ b/buttons/helpers/buttons_sbd_menu_config.js
@@ -287,7 +287,7 @@ function createConfigMenu(parent) {
 		});
 		{	// New tag
 			menu.newEntry({menuName, entryText: 'New tag...', func: () => {
-				const nTag = {weight: 0, tf: [], scoringDistribution: 'LINEAR', type: []};
+				const nTag = {weight: 0, tf: [], scoringDistribution: 'LINEAR', type: [], baseScore: 0};
 				const name = Input.string('string', '', 'Enter a name for the tag:\n\nThis is just for identification purposes, the actual tag values will be filled later.', 'Search by distance', 'myTag');
 				if (name === null) {return;}
 				'string', 'multiple', 'graph'


### PR DESCRIPTION
I add a default property to avoid messages that say it's missing. See issue #19.

`baseScore: 0`

The message then no longer appears. The menu and popup window of a new tag look like this:

<details><summary>Screenshots</summary>
<p>

![Screenshot 3](https://github.com/regorxxx/Search-by-Distance-SMP/assets/108369600/e8bcdb2a-7157-4a7e-945d-3bb8248fb3a0)

![Screenshot 4](https://github.com/regorxxx/Search-by-Distance-SMP/assets/108369600/095d6565-84e3-4647-b412-c995b7aee91c)

</p>
</details> 